### PR TITLE
ボタンレイアウト調整

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -1,13 +1,14 @@
-.buttonWrapper {
+.button-wrapper {
     display: flex;
     flex-wrap: wrap;
-    margin: 0px 16px 8px 16px;
+    align-self: center;
 }
 
 .exButton {
-    margin: 2px;
-    border: 2px solid;
-    border-radius: 8px;
+    margin: 0 0 0 5px;
+    padding: 5px 10px 5px 10px;
+    border: none;
+    border-radius: 6px;
     color: #fff;
-    text-shadow: -1px 0 black, 0 1px black, 1px 0 black, 0 -1px black;
+    background-color: rgb(134, 179, 0);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,7 @@ const observer = new MutationObserver((mutations) => {
                         const form = node.querySelector("footer[class=xkr7J]");
                         // console.log(form);
                         if (form) {
-                            form.after(buttonWrapper);
+                            form.appendChild(buttonWrapper);
                         }
                     }
                 }


### PR DESCRIPTION
# 変更点
- ボタンのデザインを変更
- クラス名「button-wrapper」に修正

## プレビュー
<img width="541" alt="image" src="https://github.com/kamesan1577/Misskey-post-interruptor/assets/85672167/5e74da00-16ad-404e-8277-c0ccdb6cca2f">
